### PR TITLE
Add aria-label to first close button

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -41,7 +41,7 @@
                 <h3 class="vm-title">
                   {{ title }}
                 </h3>
-                <button v-if="enableClose" type="button" class="vm-btn-close" @click.prevent="close"></button>
+                <button v-if="enableClose" type="button" class="vm-btn-close" aria-label="Close" @click.prevent="close"></button>
               </div>
             </slot>
             <slot name="content">


### PR DESCRIPTION
Nice work mapping the W3C recommendation to Vue!

While the top close button receives focus on modal open as it should, screen readers (macOS Voice Over at least) read the button as "times" due to the [button's css](https://github.com/kouts/vue-modal/blob/master/src/Modal.vue#L318).

This PR adds `aria-label="Close"` to the button.