### PR TITLE
Update postcss.config.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,13 +10,12 @@ module.exports = {
           const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '')
           return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g) || []
         },
-        whitelist: [],
-        whitelistPatterns: [
+        safelist: [
           /-(leave|enter|appear)(|-(to|from|active))$/,
           /^(?!(|.*?:)cursor-move).+-move$/,
           /^router-link(|-exact)-active$/,
           /data-v-.*/,
-          /vm-.*/
+          /^vm(-.*)?$/
         ]
       })
   ]


### PR DESCRIPTION
* purgecss renamed `whitelist` to `safelist` and collapsed two options into one (see their issues [#428](https://github.com/FullHuman/purgecss/issues/428) and [#439](https://github.com/FullHuman/purgecss/issues/439))
* current regexp was missing `vm` class

Context:  
I noticed that in production bundle of my Vue3 app, modals created with vue-modal appeared at the very bottom of page. After some debugging I found out the root cause is main css file missing classes needed by vue-modal. After applying changes in this PR locally, css file contained all the classes and modal in production looked as expected.